### PR TITLE
Add an merge-conflicts output indicator

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10443,6 +10443,7 @@ function run() {
                     result.stdout.includes(CHERRYPICK_CONFLICT))) {
                 yield gitExecution(['add', '*']);
                 yield gitExecution(['commit', '-m', 'Cherry picking with conflicts']);
+                core.setOutput('does_pr_have_conflicts', 'true');
             }
             else if (result.exitCode !== 0 &&
                 !result.stderr.includes(CHERRYPICK_EMPTY)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export async function run(): Promise<void> {
     ) {
       await gitExecution(['add', '*'])
       await gitExecution(['commit', '-m', 'Cherry picking with conflicts'])
+      core.setOutput('does_pr_have_conflicts', 'true')
     } else if (
       result.exitCode !== 0 &&
       !result.stderr.includes(CHERRYPICK_EMPTY)


### PR DESCRIPTION
Adds a flag indicator if merge conflicts exist between the cherry-pick branch and the target branch. The automate-cherry-pick.yml then uses this to send an indicative message

https://github.com/cyeragit/cyera/pull/42863