### PR TITLE
fix: create conflict PR for all conflict types (modify/delete, rename, etc.)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10375,7 +10375,12 @@ const utils = __importStar(__nccwpck_require__(1314));
 const github = __importStar(__nccwpck_require__(5438));
 const github_helper_1 = __nccwpck_require__(5366);
 const CHERRYPICK_EMPTY = 'The previous cherry-pick is now empty, possibly due to conflict resolution.';
-const CHERRYPICK_CONFLICT = 'CONFLICT (content): Merge conflict';
+// Matches any git cherry-pick conflict marker, e.g.:
+//   CONFLICT (content): Merge conflict in ...
+//   CONFLICT (modify/delete): ... deleted in HEAD and modified in ...
+//   CONFLICT (rename/delete): ...
+//   CONFLICT (add/add): ...
+const CHERRYPICK_CONFLICT = /^CONFLICT \(/m;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -10439,9 +10444,9 @@ function run() {
             core.info(`Cherry pick stdout: ${result.stdout}`);
             core.info(`Cherry pick stderr: ${result.stderr}`);
             if (result.exitCode !== 0 &&
-                (result.stderr.includes(CHERRYPICK_CONFLICT) ||
-                    result.stdout.includes(CHERRYPICK_CONFLICT))) {
-                yield gitExecution(['add', '*']);
+                (CHERRYPICK_CONFLICT.test(result.stderr) ||
+                    CHERRYPICK_CONFLICT.test(result.stdout))) {
+                yield gitExecution(['add', '-A']);
                 yield gitExecution(['commit', '-m', 'Cherry picking with conflicts']);
                 core.setOutput('does_pr_have_conflicts', 'true');
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ import {PullRequest} from '@octokit/webhooks-definitions/schema'
 const CHERRYPICK_EMPTY =
   'The previous cherry-pick is now empty, possibly due to conflict resolution.'
 
-const CHERRYPICK_CONFLICT = 'CONFLICT (content): Merge conflict'
+// Matches any git cherry-pick conflict marker, e.g.:
+//   CONFLICT (content): Merge conflict in ...
+//   CONFLICT (modify/delete): ... deleted in HEAD and modified in ...
+//   CONFLICT (rename/delete): ...
+//   CONFLICT (add/add): ...
+const CHERRYPICK_CONFLICT = /^CONFLICT \(/m
 
 export async function run(): Promise<void> {
   try {
@@ -85,10 +90,10 @@ export async function run(): Promise<void> {
 
     if (
       result.exitCode !== 0 &&
-      (result.stderr.includes(CHERRYPICK_CONFLICT) ||
-        result.stdout.includes(CHERRYPICK_CONFLICT))
+      (CHERRYPICK_CONFLICT.test(result.stderr) ||
+        CHERRYPICK_CONFLICT.test(result.stdout))
     ) {
-      await gitExecution(['add', '*'])
+      await gitExecution(['add', '-A'])
       await gitExecution(['commit', '-m', 'Cherry picking with conflicts'])
       core.setOutput('does_pr_have_conflicts', 'true')
     } else if (


### PR DESCRIPTION
## Problem

The cherry-pick automation (e.g. [run 27675121603](https://github.com/cyeragit/cyera/actions/runs/27675121603)) **failed instead of opening a PR** when a cherry-pick hit a `CONFLICT (modify/delete)`. Example: PR #106980 modified `package.json` in three services that had been deleted on `develop`.

The action only recognized one conflict string:

```ts
const CHERRYPICK_CONFLICT = 'CONFLICT (content): Merge conflict'
```

Any other conflict type (`modify/delete`, `rename/delete`, `add/add`, …) skipped the "commit conflicts + create PR" branch and fell through to:

```ts
throw new Error(`Unexpected error: ${result.stderr}`)
```

So the workflow errored (exit 128) and never created the conflict PR — defeating the whole point of the `does_pr_have_conflicts` path that downstream Slack messaging already supports.

## Fix

- Broaden `CHERRYPICK_CONFLICT` to a regex `/^CONFLICT \(/m` that matches **any** git conflict marker.
- Switch `git add *` → `git add -A` so deletions from modify/delete conflicts are staged (otherwise the commit would miss them).
- Rebuilt `dist/index.js`.

## Verification

Verified the new matcher against real git output strings:

| Output | Matches |
|--------|---------|
| `CONFLICT (modify/delete): ...` (the failing case) | ✅ |
| `CONFLICT (content): Merge conflict in ...` | ✅ |
| `CONFLICT (rename/delete): ...` | ✅ |
| `CONFLICT (add/add): ...` | ✅ |
| `The previous cherry-pick is now empty...` | ❌ (correct — handled separately) |
| clean success output | ❌ (correct) |

Pre-existing test timeouts in `test/index.test.ts` are unrelated (they spawn real git/network and time out at 5s identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)